### PR TITLE
Day3

### DIFF
--- a/assoc.ml
+++ b/assoc.ml
@@ -1,0 +1,17 @@
+open KNormal
+
+let rec f = function
+  | IfEq(x, y, e1, e2) -> IfEq(x, y, f e1, f e2)
+  | IfLE(x, y, e1, e2) -> IfLE(x, y, f e1, f e2)
+  | Let(xt, e1, e2) ->
+      let rec insert = function
+        | Let(yt, e3, e4) -> Let(yt, e3, insert e4)
+        | LetRec(fundefs, e) -> LetRec(fundefs, insert e)
+        | LetTuple(yts, z, e) -> LetTuple(yts, z, insert e)
+        | e -> Let(xt, e, f e2)
+      in
+      insert (f e1)
+  | LetRec({ name = xt; args = yts; body = e1 }, e2) ->
+      LetRec({ name = xt; args = yts; body = f e1 }, f e2)
+  | LetTuple(xts, y, e) -> LetTuple(xts, y, f e)
+  | e -> e

--- a/assoc.mli
+++ b/assoc.mli
@@ -1,0 +1,1 @@
+val f : KNormal.t -> KNormal.t

--- a/constFold.ml
+++ b/constFold.ml
@@ -1,0 +1,45 @@
+open KNormal
+
+let memi x env =
+  try (match M.find x env with Int(_) -> true | _ -> false)
+  with Not_found -> false
+let memf x env =
+  try (match M.find x env with Float(_) -> true | _ -> false)
+  with Not_found -> false
+let memt x env =
+  try (match M.find x env with Tuple(_) -> true | _ -> false)
+  with Not_found -> false
+
+let findi x env = match M.find x env with Int(i) -> i | _ -> raise Not_found
+let findf x env = match M.find x env with Float(i) -> i | _ -> raise Not_found
+let findt x env = match M.find x env with Tuple(i) -> i | _ -> raise Not_found
+
+let rec g env = function
+  | Var(x) when memi x env -> Int(findi x env)
+  | Neg(x) when memi x env -> Int(-(findi x env))
+  | Add(x, y) when memi x env && memi y env -> Int(findi x env + findi y env)
+  | Sub(x, y) when memi x env && memi y env -> Int(findi x env - findi y env)
+  | FNeg(x) when memf x env -> Float(-.(findf x env))
+  | FAdd(x, y) when memf x env && memf y env -> Float(findf x env +. findf y env)
+  | FSub(x, y) when memf x env && memf y env -> Float(findf x env -. findf y env)
+  | FMul(x, y) when memf x env && memf y env -> Float(findf x env *. findf y env)
+  | FDiv(x, y) when memf x env && memf y env -> Float(findf x env /. findf y env)
+  | IfEq(x, y, e1, e2) when memi x env && memi y env -> if findi x env = findi y env then g env e1 else g env e2
+  | IfEq(x, y, e1, e2) when memf x env && memf y env -> if findf x env = findf y env then g env e1 else g env e2
+  | IfEq(x, y, e1, e2) -> IfEq(x, y, g env e1, g env e2)
+  | IfLE(x, y, e1, e2) when memi x env && memi y env -> if findi x env <= findi y env then g env e1 else g env e2
+  | IfLE(x, y, e1, e2) when memf x env && memf y env -> if findf x env <= findf y env then g env e1 else g env e2
+  | IfLE(x, y, e1, e2) -> IfLE(x, y, g env e1, g env e2)
+  | Let((x, t), e1, e2) ->
+      let e1' = g env e1 in
+      let e2' = g (M.add x e1' env) e2 in
+      Let((x, t), e1', e2')
+  | LetRec({ name = x; args = ys; body = e1 }, e2) ->
+      LetRec({ name = x; args = ys; body = g env e1 }, g env e2)
+  | LetTuple(xts, y, e) when memt y env ->
+      let make_let e' xt z -> Let(xt, Var(z), e') in
+      List.fold_left2 make_let (g env e) xts (findt y env)
+  | LetTuple(xts, y, e) -> LetTuple(xts, y, g env e)
+  | e -> e
+
+let f = g M.empty

--- a/constFold.mli
+++ b/constFold.mli
@@ -1,0 +1,1 @@
+val f : KNormal.t -> KNormal.t

--- a/elim.ml
+++ b/elim.ml
@@ -1,0 +1,35 @@
+open KNormal
+
+let rec effect = function
+  | App _
+  | Put _
+  | ExtFunApp _ -> true
+  | Let(_, e1, e2) 
+  | IfEq(_, _, e1, e2) 
+  | IfLE(_, _, e1, e2) -> effect e1 || effect e2
+  | LetRec(_, e)
+  | LetTuple(_, _, e) -> effect e
+  | _ -> false
+
+let rec f = function
+  | Let((x, t), e1, e2) ->
+      let e1' = f e1 in
+      let e2' = f e2 in
+      if effect e1' || S.mem x (fv e2')
+      then Let((x, t), e1', e2')
+      else e2'
+  | LetRec({ name = (x, t); args = yts; body = e1 }, e2) ->
+      let e2' = f e2 in
+      if S.mem x (fv e2')
+      then LetRec({ name = (x, t); args = yts; body = f e1 }, e2')
+      else e2'
+  | LetTuple(xts, y, e) ->
+      let xs = List.map fst xts in
+      let e' = f e in
+      let live = fv e' in
+      if List.exists (fun x -> S.mem x live) xs
+      then LetTuple(xts, y, e')
+      else e'
+  | IfEq(x, y, e1, e2) -> IfEq(x, y, f e1, f e2)
+  | IfLE(x, y, e1, e2) -> IfLE(x, y, f e1, f e2)
+  | e -> e

--- a/elim.mli
+++ b/elim.mli
@@ -1,0 +1,1 @@
+val f : KNormal.t -> KNormal.t

--- a/inline.ml
+++ b/inline.ml
@@ -1,0 +1,32 @@
+open KNormal
+
+let threshold = ref 0
+
+let rec size = function
+  | IfEq(_, _, e1, e2)
+  | IfLE(_, _, e1, e2)
+  | Let(_, e1, e2)
+  | LetRec({ body = e1}, e2) -> 1 + size e1 + size e2
+  | LetTuple(_, _, e) -> 1 + size e
+  | _ -> 1
+
+let rec g env = function
+  | LetRec({ name = (x, t); args = yts; body = e1 }, e2) ->
+      let env = 
+          if size e1 > !threshold 
+          then env 
+          else M.add x (yts, e1) env 
+      in
+      LetRec({ name = (x, t); args = yts; body = g env e1 }, g env e2)
+  | App(x, ys) when M.mem x env ->
+      let (zs, e) = M.find x env in
+      let make_env env' (z, t) y = M.add z y env' in
+      let env' = List.fold_left2 make_env M.empty zs ys in
+      Alpha.g env' e
+  | IfEq(x, y, e1, e2) -> IfEq(x, y, g env e1, g env e2)
+  | IfLE(x, y, e1, e2) -> IfLE(x, y, g env e1, g env e2)
+  | Let(xt, e1, e2) -> Let(xt, g env e1, g env e2)
+  | LetTuple(xts, y, e) -> LetTuple(xts, y, g env e)
+  | e -> e
+
+let f e = g M.empty e

--- a/inline.mli
+++ b/inline.mli
@@ -1,0 +1,2 @@
+val threshold : int ref
+val f : KNormal.t -> KNormal.t


### PR DESCRIPTION
After K normalization, alpha conversion & beta reduction:
 * Flatten let exps of the form (let x = (let y = e1 in e2) in e3) to (let y = e1 in let x = e2 in e3)
 * Inline functions shorter than a specified threshold such that the parameters and the body of the function are directly substituted instead of function calls
 * Replace variables and simple arithmetic expressions on Ints/Floats/Tuples with actual constant values
 * Eliminate let-variables that have been made redundant by the previous constant-folding operation 